### PR TITLE
Update README with my issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,21 @@ Mac OS X example:
 ```brew install r```
 
 
-2) Install the required python packaged:
+2a) Optionally create a [virtualenv](https://pypi.python.org/pypi/virtualenv)
+
+```virtualenv env```
+
+```source env/bin/activate```
+
+This will make the next step install all needed Python packages in an isolated environment, not affecting the rest of your system.
+
+2b) Install the required python packaged
 
 ```pip install -r requirements.txt```
+
+3a) Create a tmp directory
+
+```mkdir tmp```
 
 3a) Run the following code to execute the spark python script from a terminal:
 


### PR DESCRIPTION
Had a crash because ./tmp did not exist:

```
$ spark-submit --driver-memory=6G py/readPdfs.py
Using Spark's repl log4j profile: org/apache/spark/log4j-defaults-repl.properties
To adjust logging level use sc.setLogLevel("INFO")
15/12/08 19:34:23 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
15/12/08 19:34:25 WARN MetricsSystem: Using default name DAGScheduler for source because spark.app.id is not set.
15/12/08 19:34:25 ERROR SparkContext: Error initializing SparkContext.
java.io.FileNotFoundException: File file:/home/andre/prog/repos/Spark-DS-example/tmp does not exist
```
